### PR TITLE
[csharp] [booking] Remove unused imports and fix variable name in test

### DIFF
--- a/examples/csharp/csharp-booking-01_base/src/Booking/BookingId.cs
+++ b/examples/csharp/csharp-booking-01_base/src/Booking/BookingId.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace CodelyTv.Booking
+﻿namespace CodelyTv.Booking
 {
     public sealed class BookingId
     {

--- a/examples/csharp/csharp-booking-01_base/src/Booking/CustomerName.cs
+++ b/examples/csharp/csharp-booking-01_base/src/Booking/CustomerName.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace CodelyTv.Booking
+﻿namespace CodelyTv.Booking
 {
     public sealed class CustomerName
     {

--- a/examples/csharp/csharp-booking-01_base/test/Booking.Tests/BookingShould.cs
+++ b/examples/csharp/csharp-booking-01_base/test/Booking.Tests/BookingShould.cs
@@ -33,7 +33,7 @@ namespace CodelyTv.Booking.Tests
         [Fact]
         private void GetTheCorrectStatusWhenTheBookingIsCurrentlyActive()
         {
-            var dateBeforeBookingHasStarted = new DateTime(2020, 6, 29, 15, 0, 0);
+            var dateBetweenBooking = new DateTime(2020, 6, 29, 15, 0, 0);
 
             var bookingStartDate = new DateTime(2020, 6, 26, 19, 0, 0);
             var bookingEndDate = new DateTime(2020, 7, 14, 16, 0, 0);
@@ -52,13 +52,13 @@ namespace CodelyTv.Booking.Tests
                 new TaxValue(0)
             );
 
-            Assert.Equal(BookingStatus.ACTIVE, booking.StatusFor(dateBeforeBookingHasStarted));
+            Assert.Equal(BookingStatus.ACTIVE, booking.StatusFor(dateBetweenBooking));
         }
 
         [Fact]
         private void GetTheCorrectStatusWhenTheBookingIsFinished()
         {
-            var dateBeforeBookingHasStarted = new DateTime(2020, 8, 30, 19, 0, 0);
+            var dateAfterBookingEnds = new DateTime(2020, 8, 30, 19, 0, 0);
 
             var bookingStartDate = new DateTime(2020, 6, 26, 19, 0, 0);
             var bookingEndDate = new DateTime(2020, 7, 14, 16, 0, 0);
@@ -77,7 +77,7 @@ namespace CodelyTv.Booking.Tests
                 new TaxValue(0)
             );
 
-            Assert.Equal(BookingStatus.FINISHED, booking.StatusFor(dateBeforeBookingHasStarted));
+            Assert.Equal(BookingStatus.FINISHED, booking.StatusFor(dateAfterBookingEnds));
         }
     }
 }

--- a/examples/csharp/csharp-booking-02_introduce_parameter_object/src/Booking/BookingId.cs
+++ b/examples/csharp/csharp-booking-02_introduce_parameter_object/src/Booking/BookingId.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace CodelyTv.Booking
+﻿namespace CodelyTv.Booking
 {
     public sealed class BookingId
     {

--- a/examples/csharp/csharp-booking-02_introduce_parameter_object/src/Booking/CustomerName.cs
+++ b/examples/csharp/csharp-booking-02_introduce_parameter_object/src/Booking/CustomerName.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace CodelyTv.Booking
+﻿namespace CodelyTv.Booking
 {
     public sealed class CustomerName
     {

--- a/examples/csharp/csharp-booking-02_introduce_parameter_object/src/Booking/DateRange.cs
+++ b/examples/csharp/csharp-booking-02_introduce_parameter_object/src/Booking/DateRange.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CodelyTv.Booking
 {

--- a/examples/csharp/csharp-booking-02_introduce_parameter_object/src/Booking/Discount.cs
+++ b/examples/csharp/csharp-booking-02_introduce_parameter_object/src/Booking/Discount.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace CodelyTv.Booking
+﻿namespace CodelyTv.Booking
 {
     public sealed class Discount
     {

--- a/examples/csharp/csharp-booking-02_introduce_parameter_object/test/Booking.Tests/BookingShould.cs
+++ b/examples/csharp/csharp-booking-02_introduce_parameter_object/test/Booking.Tests/BookingShould.cs
@@ -32,7 +32,7 @@ namespace CodelyTv.Booking.Tests
         [Fact]
         private void GetTheCorrectStatusWhenTheBookingIsCurrentlyActive()
         {
-            var dateBeforeBookingHasStarted = new DateTime(2020, 6, 29, 15, 0, 0);
+            var dateBetweenBooking = new DateTime(2020, 6, 29, 15, 0, 0);
 
             var bookingStartDate = new DateTime(2020, 6, 26, 19, 0, 0);
             var bookingEndDate = new DateTime(2020, 7, 14, 16, 0, 0);
@@ -50,13 +50,13 @@ namespace CodelyTv.Booking.Tests
                 new Tax(TaxType.NONE, new TaxValue(0))
             );
 
-            Assert.Equal(BookingStatus.ACTIVE, booking.StatusFor(dateBeforeBookingHasStarted));
+            Assert.Equal(BookingStatus.ACTIVE, booking.StatusFor(dateBetweenBooking));
         }
 
         [Fact]
         private void GetTheCorrectStatusWhenTheBookingIsFinished()
         {
-            var dateBeforeBookingHasStarted = new DateTime(2020, 8, 30, 19, 0, 0);
+            var dateAfterBookingEnds = new DateTime(2020, 8, 30, 19, 0, 0);
 
             var bookingStartDate = new DateTime(2020, 6, 26, 19, 0, 0);
             var bookingEndDate = new DateTime(2020, 7, 14, 16, 0, 0);
@@ -74,7 +74,7 @@ namespace CodelyTv.Booking.Tests
                 new Tax(TaxType.NONE, new TaxValue(0))
             );
 
-            Assert.Equal(BookingStatus.FINISHED, booking.StatusFor(dateBeforeBookingHasStarted));
+            Assert.Equal(BookingStatus.FINISHED, booking.StatusFor(dateAfterBookingEnds));
         }
     }
 }

--- a/examples/csharp/csharp-booking-03_preserve_whole_object/src/Booking/BookingId.cs
+++ b/examples/csharp/csharp-booking-03_preserve_whole_object/src/Booking/BookingId.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace CodelyTv.Booking
+﻿namespace CodelyTv.Booking
 {
     public sealed class BookingId
     {

--- a/examples/csharp/csharp-booking-03_preserve_whole_object/src/Booking/CustomerName.cs
+++ b/examples/csharp/csharp-booking-03_preserve_whole_object/src/Booking/CustomerName.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace CodelyTv.Booking
+﻿namespace CodelyTv.Booking
 {
     public sealed class CustomerName
     {

--- a/examples/csharp/csharp-booking-03_preserve_whole_object/src/Booking/DateRange.cs
+++ b/examples/csharp/csharp-booking-03_preserve_whole_object/src/Booking/DateRange.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CodelyTv.Booking
 {

--- a/examples/csharp/csharp-booking-03_preserve_whole_object/src/Booking/Discount.cs
+++ b/examples/csharp/csharp-booking-03_preserve_whole_object/src/Booking/Discount.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace CodelyTv.Booking
+﻿namespace CodelyTv.Booking
 {
     public sealed class Discount
     {

--- a/examples/csharp/csharp-booking-03_preserve_whole_object/test/Booking.Tests/BookingShould.cs
+++ b/examples/csharp/csharp-booking-03_preserve_whole_object/test/Booking.Tests/BookingShould.cs
@@ -32,7 +32,7 @@ namespace CodelyTv.Booking.Tests
         [Fact]
         private void GetTheCorrectStatusWhenTheBookingIsCurrentlyActive()
         {
-            var dateBeforeBookingHasStarted = new DateTime(2020, 6, 29, 15, 0, 0);
+            var dateBetweenBooking = new DateTime(2020, 6, 29, 15, 0, 0);
 
             var bookingStartDate = new DateTime(2020, 6, 26, 19, 0, 0);
             var bookingEndDate = new DateTime(2020, 7, 14, 16, 0, 0);
@@ -50,13 +50,13 @@ namespace CodelyTv.Booking.Tests
                 new Tax(TaxType.NONE, new TaxValue(0))
             );
 
-            Assert.Equal(BookingStatus.ACTIVE, booking.StatusFor(dateBeforeBookingHasStarted));
+            Assert.Equal(BookingStatus.ACTIVE, booking.StatusFor(dateBetweenBooking));
         }
 
         [Fact]
         private void GetTheCorrectStatusWhenTheBookingIsFinished()
         {
-            var dateBeforeBookingHasStarted = new DateTime(2020, 8, 30, 19, 0, 0);
+            var dateAfterBookingEnds = new DateTime(2020, 8, 30, 19, 0, 0);
 
             var bookingStartDate = new DateTime(2020, 6, 26, 19, 0, 0);
             var bookingEndDate = new DateTime(2020, 7, 14, 16, 0, 0);
@@ -74,7 +74,7 @@ namespace CodelyTv.Booking.Tests
                 new Tax(TaxType.NONE, new TaxValue(0))
             );
 
-            Assert.Equal(BookingStatus.FINISHED, booking.StatusFor(dateBeforeBookingHasStarted));
+            Assert.Equal(BookingStatus.FINISHED, booking.StatusFor(dateAfterBookingEnds));
         }
     }
 }

--- a/examples/csharp/csharp-booking-04_tell_dont_ask/src/Booking/BookingId.cs
+++ b/examples/csharp/csharp-booking-04_tell_dont_ask/src/Booking/BookingId.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace CodelyTv.Booking
+﻿namespace CodelyTv.Booking
 {
     public sealed class BookingId
     {
@@ -8,5 +6,4 @@ namespace CodelyTv.Booking
 
         public BookingId(string value) => this.value = value;
     }
-
 }

--- a/examples/csharp/csharp-booking-04_tell_dont_ask/src/Booking/CustomerName.cs
+++ b/examples/csharp/csharp-booking-04_tell_dont_ask/src/Booking/CustomerName.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace CodelyTv.Booking
+﻿namespace CodelyTv.Booking
 {
     public sealed class CustomerName
     {
@@ -8,5 +6,4 @@ namespace CodelyTv.Booking
 
         public CustomerName(string value) => this.value = value;
     }
-
 }

--- a/examples/csharp/csharp-booking-04_tell_dont_ask/src/Booking/Discount.cs
+++ b/examples/csharp/csharp-booking-04_tell_dont_ask/src/Booking/Discount.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace CodelyTv.Booking
+﻿namespace CodelyTv.Booking
 {
     public sealed class Discount
     {

--- a/examples/csharp/csharp-booking-04_tell_dont_ask/test/Booking.Tests/BookingShould.cs
+++ b/examples/csharp/csharp-booking-04_tell_dont_ask/test/Booking.Tests/BookingShould.cs
@@ -32,7 +32,7 @@ namespace CodelyTv.Booking.Tests
         [Fact]
         private void GetTheCorrectStatusWhenTheBookingIsCurrentlyActive()
         {
-            var dateBeforeBookingHasStarted = new DateTime(2020, 6, 29, 15, 0, 0);
+            var dateBetweenBooking = new DateTime(2020, 6, 29, 15, 0, 0);
 
             var bookingStartDate = new DateTime(2020, 6, 26, 19, 0, 0);
             var bookingEndDate = new DateTime(2020, 7, 14, 16, 0, 0);
@@ -50,13 +50,13 @@ namespace CodelyTv.Booking.Tests
                 new Tax(TaxType.NONE, new TaxValue(0))
             );
 
-            Assert.Equal(BookingStatus.ACTIVE, booking.StatusFor(dateBeforeBookingHasStarted));
+            Assert.Equal(BookingStatus.ACTIVE, booking.StatusFor(dateBetweenBooking));
         }
 
         [Fact]
         private void GetTheCorrectStatusWhenTheBookingIsFinished()
         {
-            var dateBeforeBookingHasStarted = new DateTime(2020, 8, 30, 19, 0, 0);
+            var dateAfterBookingEnds = new DateTime(2020, 8, 30, 19, 0, 0);
 
             var bookingStartDate = new DateTime(2020, 6, 26, 19, 0, 0);
             var bookingEndDate = new DateTime(2020, 7, 14, 16, 0, 0);
@@ -74,7 +74,7 @@ namespace CodelyTv.Booking.Tests
                 new Tax(TaxType.NONE, new TaxValue(0))
             );
 
-            Assert.Equal(BookingStatus.FINISHED, booking.StatusFor(dateBeforeBookingHasStarted));
+            Assert.Equal(BookingStatus.FINISHED, booking.StatusFor(dateAfterBookingEnds));
         }
     }
 }


### PR DESCRIPTION
- Remove unused imports
- Change `dateBeforeBookingHasStarted` to `dateBetweenBooking` in `GetTheCorrectStatusWhenTheBookingIsCurrentlyActive` method.
- Change `dateBeforeBookingHasStarted` to `dateAfterBookingEnds`  in `GetTheCorrectStatusWhenTheBookingIsFinished` method.