### PR TITLE
Codely brand image not showing in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <a href="http://codely.tv">
-    <img src="http://codely.tv/wp-content/uploads/2016/05/cropped-logo-codelyTV.png" width="192px" height="192px"/>
+  <a href="https://codely.com">
+    <img src="https://user-images.githubusercontent.com/10558907/170513882-a09eee57-7765-4ca4-b2dd-3c2e061fdad0.png" width="300px" height="92px"/>
   </a>
 </p>
 


### PR DESCRIPTION
The brand logo in the README.md have an old URL, this same issue is happening in many other repositories :(